### PR TITLE
Fix 500 in default.rb

### DIFF
--- a/lib/auto_select2/select2_search_adapter/default.rb
+++ b/lib/auto_select2/select2_search_adapter/default.rb
@@ -3,7 +3,7 @@ module AutoSelect2
     class Default < Base
       class << self
         def search_default(term, page, options)
-          if @searchable_class.blank? || @id_column.blank? || @text_columns.blank?
+          if @searchable_class || @id_column.blank? || @text_columns.blank?
             raise_not_implemented
           end
           if options[:init].nil?


### PR DESCRIPTION
Убрал проверку на .blank?, так как это порождает 500, если в @searchable_class лежит реляция, которая не возвращает элементов (пустая таблица, например).
